### PR TITLE
Make sure that dev branch of dyncss can be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "typo3/cms-core": ">=9.5.0,<11.6",
     "scssphp/scssphp": "^1.0.8",
-    "kaystrobach/dyncss": "^1.0.0"
+    "kaystrobach/dyncss": "^1.0.0 || dev-typo3-11"
   },
   "replace": {
     "typo3-ter/dyncss_scss": "self.version"


### PR DESCRIPTION
Since there is a typo3-11 branch for dyncss, it must be possible to use that branch during typo3-11 development until there will be an official releases for CMS 11.